### PR TITLE
Make Heroku::Nav::Provider thread safe

### DIFF
--- a/lib/heroku/nav.rb
+++ b/lib/heroku/nav.rb
@@ -14,6 +14,10 @@ module Heroku
       end
 
       def call(env)
+        dup._call!(env)
+      end
+
+      def _call!(env)
         @status, @headers, @body = @app.call(env)
         return [@status, @headers, @body] unless can_insert?(env)
 


### PR DESCRIPTION
Ditto.
The current implementation mutates the state by assigning ivars in order to not pass them as method arguments. This gem has a poor coverage, and I didn't wanted to change the signature of the methods involved, so I used the _"dup trick"_.

### Old implementation

```ruby
def call(env)
  @status, @headers, @body = @app.call(env)
  return [@status, @headers, @body] unless can_insert?(env)

  # ...
end

def can_insert?(env)
  # it tries to access @headers and @status from here
end
```

### Ideal implementation

```ruby
def call(env)
  @status, @headers, @body = @app.call(env)
  return [@status, @headers, @body] unless can_insert?(env, status, headers)

  # ...
end

def can_insert?(env, status, headers)
  # safely use arguments  like headers and status
end
```

Because of the poor test coverage this cannot be achieved.

### Proposed solution (this PR)

```ruby
def call(env)
  dup._call!(env)
end

def _call!(env)
  @status, @headers, @body = @app.call(env)
  # ...
end
```

When a new request is coming it triggers a `#call` invocation, which dups the instance which can be safely mutated (by `#_call!`) as it will thrown away at the end of the execution and not shared with other requests.

/cc @beanieboi @sr @azet @ngauthier 