### PR TITLE
NoMethodError: undefined method `bytesize' for Rack::Utils:Module 

### DIFF
--- a/lib/heroku/nav.rb
+++ b/lib/heroku/nav.rb
@@ -149,7 +149,7 @@ module Heroku
           match = @body.match(/(\<body[^\>]*\>)/i)
           if match && match.size > 0
             @body.insert(match.end(0), @nav)
-            @headers['Content-Length'] = Rack::Utils.bytesize(@body).to_s
+            @headers['Content-Length'] = @body.bytesize.to_s
           end
         end
       end


### PR DESCRIPTION
Mothership is currently receiving undefined method `bytesize` for `Rack::Utils:Module` rollbars.

https://rollbar.com/beanieboi/Mothership/items/10855/?item_page=1&item_count=100&#traceback

Poking around I found this [PR](https://github.com/rack/rack/pull/1103/files) against rack to add a deprecation warning for this method. According to this PR, we should be calling `bytesize` on the String instance which is what I am doing in this PR.